### PR TITLE
ODA: intuitive default ordered direction + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ end
 
 Image.pluck(:label, :position) # => [["A", 1], ["B", 2], ["C", 0]]
 Image.ordered.pluck(:label) # => ["C", "A", "B"]
-Image.ordered(:desc).pluck(:label) # => ["B", "A", "C"]
 
 # on create
 image = Image.create(label: "D")
@@ -55,6 +54,18 @@ Image.ordered.pluck(:label) # => ["C", "A", "D", "B"]
 # on destroy
 image.destroy()
 Image.ordered.pluck(:label, :position) # => [["C", 0], ["A", 1], ["B", 2]]
+```
+
+Notice that you can pass direction `:asc`/`:desc` to `ordered` scope as parameter:
+```ruby
+Image.pluck(:label, :position) # => [["A", 1], ["B", 2], ["C", 0]]
+
+# :asc by default
+Image.ordered.pluck(:label) # => ["C", "A", "B"]
+Image.ordered(:asc).pluck(:label) # => ["C", "A", "B"]
+
+# :desc
+Image.ordered(:desc).pluck(:label) # => ["B", "A", "C"]
 ```
 ### Installation
 
@@ -108,49 +119,49 @@ orderable :orderable_field_name
 | Attribute | Value | Default | Description |
 | - | - | - | - |
 | `scope` | array of symbols | `[]` | scope same as in unique index (uniqueness of this fields combination would be ensured) |
-| `auto_set` | boolean | `true` | if `true` and positioning field is not specified it on create inserts a new record on the bottom for decremental sequence or on the top for incremental sequence |
+| `auto_set` | boolean | `true` | if `true` and positioning field value is not specified it inserts a new record on the bottom for decremental sequence or on the top for incremental sequence on create |
 | `sequence` | `:incremental` or `:decremental` | `:incremental` | value used to determine positioning sequence |
-| `validate` | boolean | `true` | if `true`, it validates numericality of positioning field, as well as being in range `<0, M>`, where `M` stands for the biggest positioning field value |
+| `validate` | boolean | `true` | if `true`, it validates numericality of positioning field value, as well as being in range `<0, M>`, where `M` stands for the biggest positioning field value |
 |`from`| integer | 0 | base value from which sequence starts |
 
 ### Usage Examples
 
 #### Model with a scope
-Let's say a user has few cover and profile photos. Using *orderable* with scope will allow user to custom order them separately.
+Let's say a user has few cover and profile photos. Using *orderable* with scope will allow user to customize their order separately.
 
 ```ruby
-class Image < ActiveRecord::Base
+class Photo < ActiveRecord::Base
   orderable :position, scope: :type
 
   scope :profile, -> { where(type: 'profile') }
   scope :cover, -> { where(type: 'cover') }
 end
 
-Image.pluck(:label, :position, :type) # => [["A", 0, "profile"], ["E", 1, "cover"], ["C", 2, "profile"], ["B", 1, "profile"], ["D", 0, "cover"]]
-Image.ordered.pluck(:label) # => ["A", "B",  "C", "D", "E"]
-Image.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
-Image.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1]]
+Photo.pluck(:label, :position, :type) # => [["A", 0, "profile"], ["E", 1, "cover"], ["C", 2, "profile"], ["B", 1, "profile"], ["D", 0, "cover"]]
+Photo.ordered.pluck(:label) # => ["A", "B",  "C", "D", "E"]
+Photo.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
+Photo.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1]]
 
 # on create
-image = Image.create(label: "F", type: "profile")
-image.position # => 3
-Image.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2], ["F", 3]]
-Image.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1]]
+photo = Photo.create(label: "F", type: "profile")
+photo.position # => 3
+Photo.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2], ["F", 3]]
+Photo.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1]]
 
 # on update
-image.update(type: "cover")
-image.position # => 2
-Image.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
-Image.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1], ["F", 2]]
+photo.update(type: "cover")
+photo.position # => 2
+Photo.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
+Photo.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1], ["F", 2]]
 
-image.update(position: 1)
-Image.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
-Image.cover.ordered.pluck(:label, :position) # => [["D", 0], ["F", 1], ["E", 2]]
+photo.update(position: 1)
+Photo.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
+Photo.cover.ordered.pluck(:label, :position) # => [["D", 0], ["F", 1], ["E", 2]]
 
 # on destroy
-image.destroy()
-Image.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
-Image.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1]]
+photo.destroy()
+Photo.profile.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1],  ["C", 2]]
+Photo.cover.ordered.pluck(:label, :position) # => [["D", 0], ["E", 1]]
 ```
 #### Default push front
 
@@ -159,9 +170,9 @@ class Image < ActiveRecord::Base
   orderable :position, auto_set: true # by default
 end
 
-image= Image.create(label: "A") # => OK
+image = Image.create(label: "A") # => OK
 image.position # => 0
-image= Image.create(label: "B") # => OK
+image = Image.create(label: "B") # => OK
 Image.ordered.pluck(:label, :position) # => [["A", 0], ["B", 1]]
 
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ orderable :orderable_field_name
 | Attribute | Value | Default | Description |
 | - | - | - | - |
 | `scope` | array of symbols | `[]` | scope same as in unique index (uniqueness of this fields combination would be ensured) |
-| `auto_set` | boolean | `true` | if `true` and positioning field value is not specified it inserts a new record on the bottom for decremental sequence or on the top for incremental sequence on create |
+| `auto_set` | boolean | `true` | if `true` and positioning field value is not specified, it inserts a new record on the bottom for decremental sequence or on the top for incremental sequence on create |
 | `sequence` | `:incremental` or `:decremental` | `:incremental` | value used to determine positioning sequence |
 | `validate` | boolean | `true` | if `true`, it validates numericality of positioning field value, as well as being in range `<0, M>`, where `M` stands for the biggest positioning field value |
 |`from`| integer | 0 | base value from which sequence starts |

--- a/lib/orderable/config.rb
+++ b/lib/orderable/config.rb
@@ -22,10 +22,6 @@ module Orderable
       super(DEFAULTS.merge(normalized_options))
     end
 
-    def order_direction
-      SEQUENCES.fetch(sequence)
-    end
-
     private
 
     def normalize_options!(options)

--- a/lib/orderable/model_extension.rb
+++ b/lib/orderable/model_extension.rb
@@ -18,7 +18,7 @@ module Orderable
           validate { executor.validate_record_position(self) }
         end
 
-        scope :ordered, ->(direction = config.order_direction) { order(field => direction) }
+        scope :ordered, ->(direction = :asc) { order(field => direction) }
         define_singleton_method(:reorder) { executor.reset }
       end
     end

--- a/spec/callbacks/on_create_spec.rb
+++ b/spec/callbacks/on_create_spec.rb
@@ -72,17 +72,17 @@ RSpec.describe "on #create" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"]
             ]
           )
           .to(
             [
-              ["d", 3, "first"],
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"],
+              ["d", 3, "first"]
             ]
           )
       end
@@ -96,17 +96,17 @@ RSpec.describe "on #create" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"]
             ]
           )
           .to(
             [
-              ["c", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"]
+              ["d", 0, "second"],
+              ["b", 1, "first"],
+              ["c", 2, "first"]
             ]
           )
       end

--- a/spec/callbacks/on_destroy_spec.rb
+++ b/spec/callbacks/on_destroy_spec.rb
@@ -152,17 +152,17 @@ RSpec.describe "on #destroy" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"]
+              ["d", 0, "second"],
+              ["b", 1, "first"],
+              ["c", 2, "first"]
             ]
           )
           .to(
             [
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"]
             ]
           )
       end
@@ -180,19 +180,19 @@ RSpec.describe "on #destroy" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 3, "first"],
-              ["e", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"]
+              ["d", 0, "second"],
+              ["b", 1, "first"],
+              ["e", 2, "first"],
+              ["c", 3, "first"]
             ]
           )
           .to(
             [
-              ["c", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"]
+              ["d", 0, "second"],
+              ["b", 1, "first"],
+              ["c", 2, "first"]
             ]
           )
       end

--- a/spec/callbacks/on_update_spec.rb
+++ b/spec/callbacks/on_update_spec.rb
@@ -92,18 +92,18 @@ RSpec.describe "on #update" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"]
+              ["d", 0, "second"],
+              ["b", 1, "first"],
+              ["c", 2, "first"]
             ]
           )
           .to(
             [
-              ["c", 3, "first"],
-              ["b", 2, "first"],
+              ["a", 0, "first"],
               ["d", 1, "first"], # updated record
-              ["a", 0, "first"]
+              ["b", 2, "first"],
+              ["c", 3, "first"]
             ]
           )
       end
@@ -116,18 +116,18 @@ RSpec.describe "on #update" do
             .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
             .from(
               [
-                ["c", 2, "first"],
-                ["b", 1, "first"],
                 ["a", 0, "first"],
-                ["d", 0, "second"]
+                ["d", 0, "second"],
+                ["b", 1, "first"],
+                ["c", 2, "first"]
               ]
             )
             .to(
               [
-                ["c", 3, "first"],
-                ["d", 2, "first"], # updated record
+                ["a", 0, "first"],
                 ["b", 1, "first"],
-                ["a", 0, "first"]
+                ["d", 2, "first"], # updated record
+                ["c", 3, "first"]
               ]
             )
         end
@@ -143,18 +143,18 @@ RSpec.describe "on #update" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"]
+              ["d", 0, "second"],
+              ["b", 1, "first"],
+              ["c", 2, "first"]
             ]
           )
           .to(
             [
-              ["d", 3, "first"], # updated record
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"],
+              ["d", 3, "first"] # updated record
             ]
           )
       end
@@ -169,18 +169,18 @@ RSpec.describe "on #update" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["d", 3, "first"],
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"],
+              ["d", 3, "first"]
             ]
           )
           .to(
             [
-              ["new name", 3, "first"],
-              ["c", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["c", 2, "first"],
+              ["new name", 3, "first"]
             ]
           )
       end
@@ -195,18 +195,18 @@ RSpec.describe "on #update" do
           .to change { ModelWithManyScopes.ordered.pluck(:name, :position, :group) }
           .from(
             [
-              ["c", 3, "first"],
-              ["d", 2, "first"],
+              ["a", 0, "first"],
               ["b", 1, "first"],
-              ["a", 0, "first"]
+              ["d", 2, "first"],
+              ["c", 3, "first"]
             ]
           )
           .to(
             [
-              ["c", 2, "first"],
-              ["b", 1, "first"],
               ["a", 0, "first"],
-              ["d", 0, "second"] # updated record
+              ["d", 0, "second"], # updated record
+              ["b", 1, "first"],
+              ["c", 2, "first"]
             ]
           )
       end
@@ -408,23 +408,23 @@ RSpec.describe "on #update" do
             .to change { NoValidationModelWithOneScope.ordered.pluck(:name, :position, :kind) }
             .from(
               [
-                ["f", 9, "first"],
-                ["e", 8, "first"],
-                ["d", 7, "first"],
-                ["c", 2, "first"],
-                ["b", 1, "first"],
+                ["g", 0, "second"],
                 ["a", 0, "first"],
-                ["g", 0, "second"]
+                ["b", 1, "first"],
+                ["c", 2, "first"],
+                ["d", 7, "first"],
+                ["e", 8, "first"],
+                ["f", 9, "first"]
               ]
             ).to(
               [
-                ["g", 10, "first"],
-                ["f", 9, "first"],
-                ["e", 8, "first"],
-                ["d", 7, "first"],
-                ["c", 2, "first"],
+                ["a", 0, "first"],
                 ["b", 1, "first"],
-                ["a", 0, "first"]
+                ["c", 2, "first"],
+                ["d", 7, "first"],
+                ["e", 8, "first"],
+                ["f", 9, "first"],
+                ["g", 10, "first"]
               ]
             )
         end
@@ -438,23 +438,23 @@ RSpec.describe "on #update" do
             .to change { NoValidationModelWithOneScope.ordered.pluck(:name, :position, :kind) }
             .from(
               [
-                ["f", 9, "first"],
-                ["e", 8, "first"],
-                ["d", 7, "first"],
-                ["c", 2, "first"],
-                ["b", 1, "first"],
+                ["g", 0, "second"],
                 ["a", 0, "first"],
-                ["g", 0, "second"]
+                ["b", 1, "first"],
+                ["c", 2, "first"],
+                ["d", 7, "first"],
+                ["e", 8, "first"],
+                ["f", 9, "first"]
               ]
             ).to(
               [
-                ["f", 10, "first"],
-                ["e", 9, "first"],
-                ["d", 8, "first"],
-                ["c", 3, "first"],
-                ["b", 2, "first"],
+                ["a", 0, "first"],
                 ["g", 1, "first"],
-                ["a", 0, "first"]
+                ["b", 2, "first"],
+                ["c", 3, "first"],
+                ["d", 8, "first"],
+                ["e", 9, "first"],
+                ["f", 10, "first"]
               ]
             )
         end
@@ -472,23 +472,23 @@ RSpec.describe "on #update" do
             .to change { NoValidationModelWithOneScope.ordered.pluck(:name, :position, :kind) }
             .from(
               [
-                ["g", 10, "first"],
-                ["f", 9, "first"],
-                ["e", 8, "first"],
-                ["d", 7, "first"],
-                ["c", 2, "first"],
+                ["a", 0, "first"],
                 ["b", 1, "first"],
-                ["a", 0, "first"]
+                ["c", 2, "first"],
+                ["d", 7, "first"],
+                ["e", 8, "first"],
+                ["f", 9, "first"],
+                ["g", 10, "first"]
               ]
             ).to(
               [
-                ["f", 10, "first"],
-                ["e", 9, "first"],
-                ["d", 8, "first"],
-                ["c", 3, "first"],
-                ["b", 2, "first"],
+                ["a", 0, "first"],
                 ["g", 1, "first"],
-                ["a", 0, "first"]
+                ["b", 2, "first"],
+                ["c", 3, "first"],
+                ["d", 8, "first"],
+                ["e", 9, "first"],
+                ["f", 10, "first"]
               ]
             )
         end

--- a/spec/features/from_spec.rb
+++ b/spec/features/from_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Configuration option :from" do
 
     it "creates a new record with the highest position" do
       expect(subject.position).to eq(FromModel.maximum(:position))
-      expect(FromModel.ordered.pluck(:position)).to eq([102, 101, 100])
+      expect(FromModel.ordered.pluck(:position)).to eq([100, 101, 102])
     end
 
     context "when position attribute given" do
@@ -19,7 +19,7 @@ RSpec.describe "Configuration option :from" do
 
       it "creates a new record with a correct position" do
         expect(subject.position).to eq(101)
-        expect(FromModel.ordered.pluck(:position)).to eq([102, 101, 100])
+        expect(FromModel.ordered.pluck(:position)).to eq([100, 101, 102])
       end
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe "Configuration option :from" do
     it "removes the record and shifts others correctly" do
       expect(subject.destroy).to be_present
       expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect(FromModel.ordered.pluck(:position)).to eq([101, 100])
+      expect(FromModel.ordered.pluck(:position)).to eq([100, 101])
     end
   end
 end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe "Orderable field scope with argument" do
 
   context "when ascending order set" do
     it "returns records proper order" do
-      expect(BasicModel.ordered(:asc).pluck(:position)).to eq([0, 1, 2])
+      expect(BasicModel.ordered.pluck(:position)).to eq([0, 1, 2])
     end
   end
 
   context "when order not specified in scope" do
     it "returns records in descending order" do
-      expect(BasicModel.ordered.pluck(:position)).to eq([2, 1, 0])
+      expect(BasicModel.ordered(:desc).pluck(:position)).to eq([2, 1, 0])
     end
   end
 end

--- a/spec/features/reset_function_spec.rb
+++ b/spec/features/reset_function_spec.rb
@@ -28,40 +28,86 @@ RSpec.describe "Function :reorder" do
 
   context "without validation" do
     context "with incremental sequence" do
-      before do
-        create_list(:no_validation_model_with_many_scopes, 3, :random_position)
-        create_list(:no_validation_model_with_many_scopes, 3, :random_position, kind: "beta")
+      context "with random positions" do
+        before do
+          create_list(:no_validation_model_with_many_scopes, 3, :random_position)
+          create_list(:no_validation_model_with_many_scopes, 3, :random_position, kind: "beta")
+        end
+
+        let(:alpha_positions) { NoValidationModelWithManyScopes.ordered.where(kind: "alpha").pluck(:position) }
+        let(:beta_positions) { NoValidationModelWithManyScopes.ordered.where(kind: "beta").pluck(:position) }
+
+        before { NoValidationModelWithManyScopes.reorder }
+
+        it "reset the positions and keeps the sequential order" do
+          expect(alpha_positions).to eq((0..2).to_a)
+          expect(beta_positions).to eq((0..2).to_a)
+        end
       end
 
-      let(:alpha_positions) { NoValidationModelWithManyScopes.ordered.where(kind: "alpha").pluck(:position) }
-      let(:beta_positions) { NoValidationModelWithManyScopes.ordered.where(kind: "beta").pluck(:position) }
+      context "with preset positions" do
+        before do
+          [1, 4, 8].each { |position| create(:no_validation_model_with_many_scopes, position: position) }
+          [2, 5, 9].each { |position| create(:no_validation_model_with_many_scopes, position: position, kind: "beta") }
+        end
 
-      before { NoValidationModelWithManyScopes.reorder }
+        let(:alpha_positions) { NoValidationModelWithManyScopes.ordered.where(kind: "alpha").pluck(:position) }
+        let(:beta_positions) { NoValidationModelWithManyScopes.ordered.where(kind: "beta").pluck(:position) }
 
-      it "reset the positions and keeps the sequential order" do
-        expect(alpha_positions).to eq((0..2).to_a)
-        expect(beta_positions).to eq((0..2).to_a)
+        before { NoValidationModelWithManyScopes.reorder }
+
+        it "reset the positions and keeps the sequential order" do
+          expect(alpha_positions).to eq((0..2).to_a)
+          expect(beta_positions).to eq((0..2).to_a)
+        end
       end
     end
 
     context "with decremental sequence" do
-      before do
-        create_list(:decremental_sequence_no_validation_model_with_many_scopes, 3, :random_position)
-        create_list(:decremental_sequence_no_validation_model_with_many_scopes, 3, :random_position, kind: "beta")
+      context "with random positions" do
+        before do
+          create_list(:decremental_sequence_no_validation_model_with_many_scopes, 3, :random_position)
+          create_list(:decremental_sequence_no_validation_model_with_many_scopes, 3, :random_position, kind: "beta")
+        end
+
+        let(:alpha_positions) do
+          DecrementalSequenceNoValidationModelWithManyScopes.ordered.where(kind: "alpha").pluck(:position)
+        end
+        let(:beta_positions) do
+          DecrementalSequenceNoValidationModelWithManyScopes.ordered.where(kind: "beta").pluck(:position)
+        end
+
+        before { DecrementalSequenceNoValidationModelWithManyScopes.reorder }
+
+        it "reset the positions and keeps the sequential order" do
+          expect(alpha_positions).to eq((8..10).to_a)
+          expect(beta_positions).to eq((8..10).to_a)
+        end
       end
 
-      let(:alpha_positions) do
-        DecrementalSequenceNoValidationModelWithManyScopes.ordered.where(kind: "alpha").pluck(:position)
-      end
-      let(:beta_positions) do
-        DecrementalSequenceNoValidationModelWithManyScopes.ordered.where(kind: "beta").pluck(:position)
-      end
+      context "with preset positions" do
+        before do
+          [8, 4, -2].each do |position|
+            create(:decremental_sequence_no_validation_model_with_many_scopes, position: position)
+          end
+          [7, 2, -6].each do |position|
+            create(:decremental_sequence_no_validation_model_with_many_scopes, position: position, kind: "beta")
+          end
+        end
 
-      before { DecrementalSequenceNoValidationModelWithManyScopes.reorder }
+        let(:alpha_positions) do
+          DecrementalSequenceNoValidationModelWithManyScopes.ordered.where(kind: "alpha").pluck(:position)
+        end
+        let(:beta_positions) do
+          DecrementalSequenceNoValidationModelWithManyScopes.ordered.where(kind: "beta").pluck(:position)
+        end
 
-      it "reset the positions and keeps the sequential order" do
-        expect(alpha_positions).to eq((8..10).to_a)
-        expect(beta_positions).to eq((8..10).to_a)
+        before { DecrementalSequenceNoValidationModelWithManyScopes.reorder }
+
+        it "reset the positions and keeps the sequential order" do
+          expect(alpha_positions).to eq((8..10).to_a)
+          expect(beta_positions).to eq((8..10).to_a)
+        end
       end
     end
   end

--- a/spec/features/reset_function_spec.rb
+++ b/spec/features/reset_function_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Function :reorder" do
     before { ModelWithManyScopes.reorder }
 
     it "reset the positions and keeps the sequential order" do
-      expect(alpha_positions).to eq((0..2).to_a.reverse)
-      expect(beta_positions).to eq((0..2).to_a.reverse)
+      expect(alpha_positions).to eq((0..2).to_a)
+      expect(beta_positions).to eq((0..2).to_a)
     end
   end
 
@@ -39,8 +39,8 @@ RSpec.describe "Function :reorder" do
       before { NoValidationModelWithManyScopes.reorder }
 
       it "reset the positions and keeps the sequential order" do
-        expect(alpha_positions).to eq((0..2).to_a.reverse)
-        expect(beta_positions).to eq((0..2).to_a.reverse)
+        expect(alpha_positions).to eq((0..2).to_a)
+        expect(beta_positions).to eq((0..2).to_a)
       end
     end
 


### PR DESCRIPTION
Like rodzena said: It don't feel intuitive for `ordered` scope without argument to sort by descending positioning field. Since we have provided sequence `incremental/decremental` and `auto_set` options, it is imo a good idea to don't change scope's default direction. Then incremental sequence + auto_set would mean default_push_back and decremental + auto_set would mean default_push_front. This solution provides more possibilities in comparision to current implementation, where it is always default_push_front.